### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,6 +3,7 @@
 
 name: Java CI with Gradle
 
+# Configure when to trigger workflow here
 on:
   push:
     branches: [ main ]
@@ -13,35 +14,54 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      LATEST_VERSION: "1.21"
+
+      # Warning: Don't add too many versions because it takes a lot of space in the artifacts,
+      # and I've gotten an email from GitHub about it so please just don't.
+      VERSIONS_TO_BUILD: "1.16.5 1.17.1 1.18.2 1.20.4 1.21"
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+
+      - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Create versions directory and mainProject
+        run: |
+          mkdir -p ./versions
+          if [ ! -f ./versions/mainProject ]; then
+            echo $LATEST_VERSION > ./versions/mainProject
+          fi
+
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Create artifact directory structure
+        run: |
+          mkdir -p artifacts
+          for version in $VERSIONS_TO_BUILD; do
+            mkdir -p artifacts/$version/devlibs
+            mkdir -p artifacts/$version/libs
+            cp ./versions/$version/build/devlibs/*.jar artifacts/$version/devlibs/
+            cp ./versions/$version/build/libs/*.jar artifacts/$version/libs/
+          done
+
+      - name: Compute hashes
+        run: |
+          touch artifacts/hashes.txt
+          for jar in $(find artifacts -name '*.jar'); do
+            sha256sum $jar >> artifacts/hashes.txt
+          done
 
       - name: Archive Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts
-          path: ./build/libs
-
-      - name: Hash Artifacts
-        run: |
-          for u in $(ls) 
-          do
-          echo "$(sha256sum $u)" >> hashes.sha256
-          done
-        shell: bash
-        working-directory: ./build/libs
-
-      - name: Upload Hashes
-        uses: actions/upload-artifact@v2
-        with:
-          name: Hashes
-          path: ./build/libs/hashes.sha256
+          path: artifacts

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,9 +1,5 @@
-# This workflow will build a Java project with Gradle
-# For more information check https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
 name: Java CI with Gradle
 
-# Configure when to trigger workflow here
 on:
   push:
     branches: [ main ]
@@ -16,7 +12,8 @@ jobs:
 
     env:
       LATEST_VERSION: "1.21"
-
+      INCLUDE_DEVLIBS: "true"
+      
       # Warning: Don't add too many versions because it takes a lot of space in the artifacts,
       # and I've gotten an email from GitHub about it so please just don't.
       VERSIONS_TO_BUILD: "1.16.5 1.17.1 1.18.2 1.20.4 1.21"
@@ -47,10 +44,12 @@ jobs:
         run: |
           mkdir -p artifacts
           for version in $VERSIONS_TO_BUILD; do
-            mkdir -p artifacts/$version/devlibs
             mkdir -p artifacts/$version/libs
-            cp ./versions/$version/build/devlibs/*.jar artifacts/$version/devlibs/
             cp ./versions/$version/build/libs/*.jar artifacts/$version/libs/
+            if [ "$INCLUDE_DEVLIBS" = "true" ]; then
+              mkdir -p artifacts/$version/devlibs
+              cp ./versions/$version/build/devlibs/*.jar artifacts/$version/devlibs/
+            fi
           done
 
       - name: Compute hashes


### PR DESCRIPTION
## Fixes #13 for the new build structure (for builds located in ./versions)

this workflow can help access the built mod (.jars) faster,
by auto building when triggered. configure in the `env` section

you can also now **link the head artifact and download it** with (nightly.link):
https://nightly.link/MiranCZ/altoclef/workflows/gradle/main/Artifacts.zip

**note: First public pull request ever, sorry if i messed anything up.**

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.