### PR TITLE
fix two bugs

### DIFF
--- a/src/main/java/adris/altoclef/tasks/container/LootContainerTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/LootContainerTask.java
@@ -102,7 +102,11 @@ public class LootContainerTask extends Task {
 
     @Override
     protected boolean isEqual(Task other) {
-        return other instanceof LootContainerTask && targets.equals(((LootContainerTask) other).targets);
+        if (other instanceof LootContainerTask lootContainerTask) {
+            return targets.equals(lootContainerTask.targets) &&
+                chest.equals(lootContainerTask.chest);
+        }
+        return false;
     }
 
     private Optional<Slot> getAMatchingSlot(AltoClef mod) {

--- a/src/main/java/adris/altoclef/tasks/container/SmeltInBlastFurnaceTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/SmeltInBlastFurnaceTask.java
@@ -195,7 +195,7 @@ public class SmeltInBlastFurnaceTask extends ResourceTask {
                     - totalFuelInBlastFurnace;
 
             // We don't have enough materials...
-            if (mod.getItemStorage().getItemCountInventoryOnly(materialTarget.getMatches()) < materialsNeeded) {
+            if (mod.getItemStorage().getItemCount(materialTarget.getMatches()) < materialsNeeded) {
                 setDebugState("Getting Materials");
                 return getMaterialTask(_target.getMaterial());
             }

--- a/src/main/java/adris/altoclef/tasks/container/SmeltInFurnaceTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/SmeltInFurnaceTask.java
@@ -195,7 +195,7 @@ public class SmeltInFurnaceTask extends ResourceTask {
                     - totalFuelInFurnace;
 
             // We don't have enough materials...
-            if (mod.getItemStorage().getItemCountInventoryOnly(materialTarget.getMatches()) < materialsNeeded) {
+            if (mod.getItemStorage().getItemCount(materialTarget.getMatches()) < materialsNeeded) {
                 setDebugState("Getting Materials");
                 return getMaterialTask(target.getMaterial());
             }

--- a/src/main/java/adris/altoclef/tasks/container/SmeltInSmokerTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/SmeltInSmokerTask.java
@@ -192,7 +192,7 @@ public class SmeltInSmokerTask extends ResourceTask {
                     - totalFuelInSmoker;
 
             // We don't have enough materials...
-            if (mod.getItemStorage().getItemCountInventoryOnly(materialTarget.getMatches()) < materialsNeeded) {
+            if (mod.getItemStorage().getItemCount(materialTarget.getMatches()) < materialsNeeded) {
                 setDebugState("Getting Materials");
                 return getMaterialTask(_target.getMaterial());
             }


### PR DESCRIPTION
## 1. infinite `LootContainerTask` in desert pyramids.
the `isEqual` method within `LootContainerTask` was invalid, it did not compare the chests position.

caused `BeatMinecraftTask` to get stuck while looting desert pyramids:
![Screenshot 2025-04-19 030156](https://github.com/user-attachments/assets/dbf0dc1c-676d-4a4e-b122-7a1967399e44)

fixed that here:
```diff
diff --git a/src/main/java/adris/altoclef/tasks/container/LootContainerTask.java b/src/main/java/adris/altoclef/tasks/container/LootContainerTask.java
index b29a6b45..5d549c7e 100644
--- a/src/main/java/adris/altoclef/tasks/container/LootContainerTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/LootContainerTask.java
@@ -102,7 +102,11 @@ public class LootContainerTask extends Task {

     @Override
     protected boolean isEqual(Task other) {
-        return other instanceof LootContainerTask && targets.equals(((LootContainerTask) other).targets);
+        if (other instanceof LootContainerTask lootContainerTask) {
+            return targets.equals(lootContainerTask.targets) &&
+                chest.equals(lootContainerTask.chest);
+        }
+        return false;
     }
```

## 2. infinite crafting loop while crafting smelting container
`SmeltInFurnaceTask` (and others) trying to smelt the materials that its using to make the furnace.

[heres a discord message that contains video of this happening](https://discord.com/channels/846150381213843497/882827789210882078/1359951186962288947)


fixed that here:
```diff
diff --git a/src/main/java/adris/altoclef/tasks/container/SmeltInBlastFurnaceTask.java b/src/main/java/adris/altoclef/tasks/container/SmeltInBlastFurnaceTask.java
index 678e146d..94811943 100644
--- a/src/main/java/adris/altoclef/tasks/container/SmeltInBlastFurnaceTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/SmeltInBlastFurnaceTask.java
@@ -195,7 +195,7 @@ public class SmeltInBlastFurnaceTask extends ResourceTask {
                     - totalFuelInBlastFurnace;

             // We don't have enough materials...
-            if (mod.getItemStorage().getItemCountInventoryOnly(materialTarget.getMatches()) < materialsNeeded) {
+            if (mod.getItemStorage().getItemCount(materialTarget.getMatches()) < materialsNeeded) {
                 setDebugState("Getting Materials");
                 return getMaterialTask(_target.getMaterial());
             }
...
```
## (change also applied to every other SmeltIn whatever Task)

and heres the filled out template:
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
