### PR TITLE
Fix Null Pointer Crash in WorldSurvivalChain.java when Paused

### DIFF
--- a/src/main/java/adris/altoclef/chains/WorldSurvivalChain.java
+++ b/src/main/java/adris/altoclef/chains/WorldSurvivalChain.java
@@ -157,6 +157,9 @@ public class WorldSurvivalChain extends SingleTaskChain {
     }
 
     private boolean isStuckInNetherPortal() {
+        if (AltoClef.getInstance().getUserTaskChain().getCurrentTask() == null) {
+            return false;
+        }
         return WorldHelper.isInNetherPortal()
                 && !AltoClef.getInstance().getUserTaskChain().getCurrentTask().thisOrChildSatisfies(task -> task instanceof EnterNetherPortalTask);
     }


### PR DESCRIPTION
When entering a nether portal, without this change, getCurrentTask returns null, so calling member variables from it crashes the game. 

**This is fixed by implementing a check to see if getCurrentTask is null and returning `false` if it is.**

